### PR TITLE
adds troubleshooting scenario for Procfile.dev start to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@
     * may need to do 'gem install bundler'
 * foreman start -f Procfile.dev
     * may need to do 'npm install -g foreman'
+    * if this fails with the error ```/bin/sh: react-scripts: command not found```, may need to:
+    ```bash
+     cd offline_client 
+     yarn
+    ```
 * http://localhost:3100
     * 	Look for Online Yay!!!
 


### PR DESCRIPTION
I may have had trouble with the "foreman start -f Procfile.dev" command because I used "gem install foreman" before the README was updated with instructions to use npm, but that is just a hypothesis.
Not sure if this solution of running a yarn install specifically for the offline_client directory is ideal, but it did enable me to get the server up and running.