### PR TITLE
Adds groups_evals API with a GET 'groups_evals/by_evaluator/:id' route

### DIFF
--- a/app/assets/javascripts/groups_evals.coffee
+++ b/app/assets/javascripts/groups_evals.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/groups_evals.scss
+++ b/app/assets/stylesheets/groups_evals.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the GroupsEvals controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,84 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px;
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a {
+  color: #000;
+
+  &:visited {
+    color: #666;
+  }
+
+  &:hover {
+    color: #fff;
+    background-color: #000;
+  }
+}
+
+th {
+  padding-bottom: 5px;
+}
+
+td {
+  padding: 0 5px 7px;
+}
+
+div {
+  &.field, &.actions {
+    margin-bottom: 10px;
+  }
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+
+  h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 5px 5px 5px 15px;
+    font-size: 12px;
+    margin: -7px -7px 0;
+    background-color: #c00;
+    color: #fff;
+  }
+
+  ul li {
+    font-size: 12px;
+    list-style: square;
+  }
+}
+
+label {
+  display: block;
+}

--- a/app/controllers/groups_evals_controller.rb
+++ b/app/controllers/groups_evals_controller.rb
@@ -1,0 +1,80 @@
+class GroupsEvalsController < ApplicationController
+  before_action :set_groups_eval, only: [:show, :edit, :update, :destroy]
+
+  # GET /groups_evals
+  # GET /groups_evals.json
+  def index
+    @groups_evals = GroupsEval.all
+  end
+
+  def by_evaluator
+    puts "params: #{params.inspect}"
+    @evals = GroupsEval.where(evaluator_group_user_id: params[:id]).find_each
+    render json: @evals, status: :ok
+  end
+
+  # GET /groups_evals/1
+  # GET /groups_evals/1.json
+  def show
+  end
+
+  # GET /groups_evals/new
+  def new
+    @groups_eval = GroupsEval.new
+  end
+
+  # GET /groups_evals/1/edit
+  def edit
+  end
+
+  # POST /groups_evals
+  # POST /groups_evals.json
+  def create
+    @groups_eval = GroupsEval.new(groups_eval_params)
+
+    respond_to do |format|
+      if @groups_eval.save
+        format.html { redirect_to @groups_eval, notice: 'Groups eval was successfully created.' }
+        format.json { render :show, status: :created, location: @groups_eval }
+      else
+        format.html { render :new }
+        format.json { render json: @groups_eval.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /groups_evals/1
+  # PATCH/PUT /groups_evals/1.json
+  def update
+    respond_to do |format|
+      if @groups_eval.update(groups_eval_params)
+        format.html { redirect_to @groups_eval, notice: 'Groups eval was successfully updated.' }
+        format.json { render :show, status: :ok, location: @groups_eval }
+      else
+        format.html { render :edit }
+        format.json { render json: @groups_eval.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /groups_evals/1
+  # DELETE /groups_evals/1.json
+  def destroy
+    @groups_eval.destroy
+    respond_to do |format|
+      format.html { redirect_to groups_evals_url, notice: 'Groups eval was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_groups_eval
+      @groups_eval = GroupsEval.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def groups_eval_params
+      params.require(:groups_eval).permit(:year_id, :semester, :school_id, :grade, :group_id, :evaluator_user_id, :evaluator_group_user_id, :portf_plan_rating, :portf_analysis_rating, :proto_title_rating, :proto_rating, :poster_abstract_rating, :poster_intro_abstr_rating, :poster_mat_meth_rating, :poster_results_rating, :poster_discussion_rating, :poster_citation_rating, :poster_design_rating, :poster_summary_comments, :invalid, :created_at, :updated_at)
+    end
+end

--- a/app/helpers/groups_evals_helper.rb
+++ b/app/helpers/groups_evals_helper.rb
@@ -1,0 +1,2 @@
+module GroupsEvalsHelper
+end

--- a/app/models/groups_eval.rb
+++ b/app/models/groups_eval.rb
@@ -1,0 +1,7 @@
+class GroupsEval < ApplicationRecord
+	def self.instance_method_already_implemented?(method_name)
+	  return true if method_name == 'invalid'
+	  return true if method_name == 'invalid?'
+	  super
+	end
+end

--- a/app/views/groups_evals/_form.html.erb
+++ b/app/views/groups_evals/_form.html.erb
@@ -1,0 +1,127 @@
+<%= form_with(model: groups_eval, local: true) do |form| %>
+  <% if groups_eval.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(groups_eval.errors.count, "error") %> prohibited this groups_eval from being saved:</h2>
+
+      <ul>
+      <% groups_eval.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :year_id %>
+    <%= form.number_field :year_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :semester %>
+    <%= form.text_field :semester %>
+  </div>
+
+  <div class="field">
+    <%= form.label :school_id %>
+    <%= form.number_field :school_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :grade %>
+    <%= form.text_field :grade %>
+  </div>
+
+  <div class="field">
+    <%= form.label :group_id %>
+    <%= form.number_field :group_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :evaluator_user_id %>
+    <%= form.number_field :evaluator_user_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :evaluator_group_user_id %>
+    <%= form.number_field :evaluator_group_user_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :portf_plan_rating %>
+    <%= form.text_field :portf_plan_rating %>
+  </div>
+
+  <div class="field">
+    <%= form.label :portf_analysis_rating %>
+    <%= form.text_field :portf_analysis_rating %>
+  </div>
+
+  <div class="field">
+    <%= form.label :proto_title_rating %>
+    <%= form.text_field :proto_title_rating %>
+  </div>
+
+  <div class="field">
+    <%= form.label :proto_rating %>
+    <%= form.text_field :proto_rating %>
+  </div>
+
+  <div class="field">
+    <%= form.label :poster_abstract_rating %>
+    <%= form.text_field :poster_abstract_rating %>
+  </div>
+
+  <div class="field">
+    <%= form.label :poster_intro_abstr_rating %>
+    <%= form.text_field :poster_intro_abstr_rating %>
+  </div>
+
+  <div class="field">
+    <%= form.label :poster_mat_meth_rating %>
+    <%= form.text_field :poster_mat_meth_rating %>
+  </div>
+
+  <div class="field">
+    <%= form.label :poster_results_rating %>
+    <%= form.text_field :poster_results_rating %>
+  </div>
+
+  <div class="field">
+    <%= form.label :poster_discussion_rating %>
+    <%= form.text_field :poster_discussion_rating %>
+  </div>
+
+  <div class="field">
+    <%= form.label :poster_citation_rating %>
+    <%= form.text_field :poster_citation_rating %>
+  </div>
+
+  <div class="field">
+    <%= form.label :poster_design_rating %>
+    <%= form.text_field :poster_design_rating %>
+  </div>
+
+  <div class="field">
+    <%= form.label :poster_summary_comments %>
+    <%= form.text_field :poster_summary_comments %>
+  </div>
+
+  <div class="field">
+    <%= form.label :invalid %>
+    <%= form.check_box :invalid %>
+  </div>
+
+  <div class="field">
+    <%= form.label :created_at %>
+    <%= form.datetime_select :created_at %>
+  </div>
+
+  <div class="field">
+    <%= form.label :updated_at %>
+    <%= form.datetime_select :updated_at %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/groups_evals/_groups_eval.json.jbuilder
+++ b/app/views/groups_evals/_groups_eval.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! groups_eval, :id, :year_id, :semester, :school_id, :grade, :group_id, :evaluator_user_id, :evaluator_group_user_id, :portf_plan_rating, :portf_analysis_rating, :proto_title_rating, :proto_rating, :poster_abstract_rating, :poster_intro_abstr_rating, :poster_mat_meth_rating, :poster_results_rating, :poster_discussion_rating, :poster_citation_rating, :poster_design_rating, :poster_summary_comments, :invalid, :created_at, :updated_at, :created_at, :updated_at
+json.url groups_eval_url(groups_eval, format: :json)

--- a/app/views/groups_evals/edit.html.erb
+++ b/app/views/groups_evals/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Groups Eval</h1>
+
+<%= render 'form', groups_eval: @groups_eval %>
+
+<%= link_to 'Show', @groups_eval %> |
+<%= link_to 'Back', groups_evals_path %>

--- a/app/views/groups_evals/index.html.erb
+++ b/app/views/groups_evals/index.html.erb
@@ -1,0 +1,69 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Groups Evals</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Year</th>
+      <th>Semester</th>
+      <th>School</th>
+      <th>Grade</th>
+      <th>Group</th>
+      <th>Evaluator user</th>
+      <th>Evaluator group user</th>
+      <th>Portf plan rating</th>
+      <th>Portf analysis rating</th>
+      <th>Proto title rating</th>
+      <th>Proto rating</th>
+      <th>Poster abstract rating</th>
+      <th>Poster intro abstr rating</th>
+      <th>Poster mat meth rating</th>
+      <th>Poster results rating</th>
+      <th>Poster discussion rating</th>
+      <th>Poster citation rating</th>
+      <th>Poster design rating</th>
+      <th>Poster summary comments</th>
+      <th>Invalid</th>
+      <th>Created at</th>
+      <th>Updated at</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @groups_evals.each do |groups_eval| %>
+      <tr>
+        <td><%= groups_eval.year_id %></td>
+        <td><%= groups_eval.semester %></td>
+        <td><%= groups_eval.school_id %></td>
+        <td><%= groups_eval.grade %></td>
+        <td><%= groups_eval.group_id %></td>
+        <td><%= groups_eval.evaluator_user_id %></td>
+        <td><%= groups_eval.evaluator_group_user_id %></td>
+        <td><%= groups_eval.portf_plan_rating %></td>
+        <td><%= groups_eval.portf_analysis_rating %></td>
+        <td><%= groups_eval.proto_title_rating %></td>
+        <td><%= groups_eval.proto_rating %></td>
+        <td><%= groups_eval.poster_abstract_rating %></td>
+        <td><%= groups_eval.poster_intro_abstr_rating %></td>
+        <td><%= groups_eval.poster_mat_meth_rating %></td>
+        <td><%= groups_eval.poster_results_rating %></td>
+        <td><%= groups_eval.poster_discussion_rating %></td>
+        <td><%= groups_eval.poster_citation_rating %></td>
+        <td><%= groups_eval.poster_design_rating %></td>
+        <td><%= groups_eval.poster_summary_comments %></td>
+        <td><%= groups_eval.invalid %></td>
+        <td><%= groups_eval.created_at %></td>
+        <td><%= groups_eval.updated_at %></td>
+        <td><%= link_to 'Show', groups_eval %></td>
+        <td><%= link_to 'Edit', edit_groups_eval_path(groups_eval) %></td>
+        <td><%= link_to 'Destroy', groups_eval, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Groups Eval', new_groups_eval_path %>

--- a/app/views/groups_evals/index.json.jbuilder
+++ b/app/views/groups_evals/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @groups_evals, partial: "groups_evals/groups_eval", as: :groups_eval

--- a/app/views/groups_evals/new.html.erb
+++ b/app/views/groups_evals/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Groups Eval</h1>
+
+<%= render 'form', groups_eval: @groups_eval %>
+
+<%= link_to 'Back', groups_evals_path %>

--- a/app/views/groups_evals/show.html.erb
+++ b/app/views/groups_evals/show.html.erb
@@ -1,0 +1,114 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Year:</strong>
+  <%= @groups_eval.year_id %>
+</p>
+
+<p>
+  <strong>Semester:</strong>
+  <%= @groups_eval.semester %>
+</p>
+
+<p>
+  <strong>School:</strong>
+  <%= @groups_eval.school_id %>
+</p>
+
+<p>
+  <strong>Grade:</strong>
+  <%= @groups_eval.grade %>
+</p>
+
+<p>
+  <strong>Group:</strong>
+  <%= @groups_eval.group_id %>
+</p>
+
+<p>
+  <strong>Evaluator user:</strong>
+  <%= @groups_eval.evaluator_user_id %>
+</p>
+
+<p>
+  <strong>Evaluator group user:</strong>
+  <%= @groups_eval.evaluator_group_user_id %>
+</p>
+
+<p>
+  <strong>Portf plan rating:</strong>
+  <%= @groups_eval.portf_plan_rating %>
+</p>
+
+<p>
+  <strong>Portf analysis rating:</strong>
+  <%= @groups_eval.portf_analysis_rating %>
+</p>
+
+<p>
+  <strong>Proto title rating:</strong>
+  <%= @groups_eval.proto_title_rating %>
+</p>
+
+<p>
+  <strong>Proto rating:</strong>
+  <%= @groups_eval.proto_rating %>
+</p>
+
+<p>
+  <strong>Poster abstract rating:</strong>
+  <%= @groups_eval.poster_abstract_rating %>
+</p>
+
+<p>
+  <strong>Poster intro abstr rating:</strong>
+  <%= @groups_eval.poster_intro_abstr_rating %>
+</p>
+
+<p>
+  <strong>Poster mat meth rating:</strong>
+  <%= @groups_eval.poster_mat_meth_rating %>
+</p>
+
+<p>
+  <strong>Poster results rating:</strong>
+  <%= @groups_eval.poster_results_rating %>
+</p>
+
+<p>
+  <strong>Poster discussion rating:</strong>
+  <%= @groups_eval.poster_discussion_rating %>
+</p>
+
+<p>
+  <strong>Poster citation rating:</strong>
+  <%= @groups_eval.poster_citation_rating %>
+</p>
+
+<p>
+  <strong>Poster design rating:</strong>
+  <%= @groups_eval.poster_design_rating %>
+</p>
+
+<p>
+  <strong>Poster summary comments:</strong>
+  <%= @groups_eval.poster_summary_comments %>
+</p>
+
+<p>
+  <strong>Invalid:</strong>
+  <%= @groups_eval.invalid %>
+</p>
+
+<p>
+  <strong>Created at:</strong>
+  <%= @groups_eval.created_at %>
+</p>
+
+<p>
+  <strong>Updated at:</strong>
+  <%= @groups_eval.updated_at %>
+</p>
+
+<%= link_to 'Edit', edit_groups_eval_path(@groups_eval) %> |
+<%= link_to 'Back', groups_evals_path %>

--- a/app/views/groups_evals/show.json.jbuilder
+++ b/app/views/groups_evals/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "groups_evals/groups_eval", groups_eval: @groups_eval

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  
+  config.logger = Logger.new(STDOUT)
+  config.logger.level = Logger::DEBUG
+  #Log DEBUG level statements during testing
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+ resources :groups_evals do
+    collection do
+    	get 'by_evaluator/:id', to: 'groups_evals#by_evaluator', as: 'by_evaluator'
+    end
+  end
   get 'home/index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 

--- a/test/controllers/groups_evals_controller_test.rb
+++ b/test/controllers/groups_evals_controller_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+require 'json'
+
+class GroupsEvalsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @groups_eval = groups_evals(:one)
+  end
+
+  test "should get index" do
+    get groups_evals_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_groups_eval_url
+    assert_response :success
+  end
+
+  test "should create groups_eval" do
+    assert_difference('GroupsEval.count') do
+      post groups_evals_url, params: { groups_eval: { created_at: @groups_eval.created_at, evaluator_group_user_id: @groups_eval.evaluator_group_user_id, evaluator_user_id: @groups_eval.evaluator_user_id, grade: @groups_eval.grade, group_id: @groups_eval.group_id, invalid: @groups_eval.invalid, portf_analysis_rating: @groups_eval.portf_analysis_rating, portf_plan_rating: @groups_eval.portf_plan_rating, poster_abstract_rating: @groups_eval.poster_abstract_rating, poster_citation_rating: @groups_eval.poster_citation_rating, poster_design_rating: @groups_eval.poster_design_rating, poster_discussion_rating: @groups_eval.poster_discussion_rating, poster_intro_abstr_rating: @groups_eval.poster_intro_abstr_rating, poster_mat_meth_rating: @groups_eval.poster_mat_meth_rating, poster_results_rating: @groups_eval.poster_results_rating, poster_summary_comments: @groups_eval.poster_summary_comments, proto_rating: @groups_eval.proto_rating, proto_title_rating: @groups_eval.proto_title_rating, school_id: @groups_eval.school_id, semester: @groups_eval.semester, updated_at: @groups_eval.updated_at, year_id: @groups_eval.year_id } }
+    end
+
+    assert_redirected_to groups_eval_url(GroupsEval.last)
+  end
+
+  test "should show groups_eval" do
+    get groups_eval_url(@groups_eval)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_groups_eval_url(@groups_eval)
+    assert_response :success
+  end
+
+  test "should update groups_eval" do
+    patch groups_eval_url(@groups_eval), params: { groups_eval: { created_at: @groups_eval.created_at, evaluator_group_user_id: @groups_eval.evaluator_group_user_id, evaluator_user_id: @groups_eval.evaluator_user_id, grade: @groups_eval.grade, group_id: @groups_eval.group_id, invalid: @groups_eval.invalid, portf_analysis_rating: @groups_eval.portf_analysis_rating, portf_plan_rating: @groups_eval.portf_plan_rating, poster_abstract_rating: @groups_eval.poster_abstract_rating, poster_citation_rating: @groups_eval.poster_citation_rating, poster_design_rating: @groups_eval.poster_design_rating, poster_discussion_rating: @groups_eval.poster_discussion_rating, poster_intro_abstr_rating: @groups_eval.poster_intro_abstr_rating, poster_mat_meth_rating: @groups_eval.poster_mat_meth_rating, poster_results_rating: @groups_eval.poster_results_rating, poster_summary_comments: @groups_eval.poster_summary_comments, proto_rating: @groups_eval.proto_rating, proto_title_rating: @groups_eval.proto_title_rating, school_id: @groups_eval.school_id, semester: @groups_eval.semester, updated_at: @groups_eval.updated_at, year_id: @groups_eval.year_id } }
+    assert_redirected_to groups_eval_url(@groups_eval)
+  end
+
+  test "should get all groups_evals with evaluator_group_user_id 1" do 
+    get by_evaluator_groups_evals_url(@groups_eval.evaluator_group_user_id) 
+    evals = parse_response response.body 
+    assert_response :success
+    assert_equal(Array, evals.class, "by_evaluator test: parsed response body should be an Array of hashes")
+    evals.each do |ev|
+
+      assert_equal(@groups_eval.evaluator_group_user_id, ev["evaluator_group_user_id"], "by_evaluator test: ev['evaluator_group_user_id'] should be equal to @groups_eval.evaluator_group_user_id") 
+    end
+  end
+
+  test "should destroy groups_eval" do
+    assert_difference('GroupsEval.count', -1) do
+      delete groups_eval_url(@groups_eval)
+    end
+
+    assert_redirected_to groups_evals_url
+  end
+  
+  def parse_response (res)
+    JSON.parse(res)
+  end
+
+end

--- a/test/fixtures/groups_evals.yml
+++ b/test/fixtures/groups_evals.yml
@@ -1,0 +1,49 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  year_id: 1
+  semester: MyString
+  school_id: 1
+  grade: MyString
+  group_id: 1
+  evaluator_user_id: 1
+  evaluator_group_user_id: 1
+  portf_plan_rating: MyString
+  portf_analysis_rating: MyString
+  proto_title_rating: MyString
+  proto_rating: MyString
+  poster_abstract_rating: MyString
+  poster_intro_abstr_rating: MyString
+  poster_mat_meth_rating: MyString
+  poster_results_rating: MyString
+  poster_discussion_rating: MyString
+  poster_citation_rating: MyString
+  poster_design_rating: MyString
+  poster_summary_comments: MyString
+  invalid: false
+  created_at: 2019-09-05 00:25:20
+  updated_at: 2019-09-05 00:25:20
+
+two:
+  year_id: 1
+  semester: MyString
+  school_id: 1
+  grade: MyString
+  group_id: 1
+  evaluator_user_id: 1
+  evaluator_group_user_id: 1
+  portf_plan_rating: MyString
+  portf_analysis_rating: MyString
+  proto_title_rating: MyString
+  proto_rating: MyString
+  poster_abstract_rating: MyString
+  poster_intro_abstr_rating: MyString
+  poster_mat_meth_rating: MyString
+  poster_results_rating: MyString
+  poster_discussion_rating: MyString
+  poster_citation_rating: MyString
+  poster_design_rating: MyString
+  poster_summary_comments: MyString
+  invalid: false
+  created_at: 2019-09-05 00:25:20
+  updated_at: 2019-09-05 00:25:20

--- a/test/models/groups_eval_test.rb
+++ b/test/models/groups_eval_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupsEvalTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/groups_evals_test.rb
+++ b/test/system/groups_evals_test.rb
@@ -1,0 +1,85 @@
+require "application_system_test_case"
+
+class GroupsEvalsTest < ApplicationSystemTestCase
+  setup do
+    @groups_eval = groups_evals(:one)
+  end
+
+  test "visiting the index" do
+    visit groups_evals_url
+    assert_selector "h1", text: "Groups Evals"
+  end
+
+  test "creating a Groups eval" do
+    visit groups_evals_url
+    click_on "New Groups Eval"
+
+    fill_in "Created at", with: @groups_eval.created_at
+    fill_in "Evaluator group user", with: @groups_eval.evaluator_group_user_id
+    fill_in "Evaluator user", with: @groups_eval.evaluator_user_id
+    fill_in "Grade", with: @groups_eval.grade
+    fill_in "Group", with: @groups_eval.group_id
+    check "Invalid" if @groups_eval.invalid
+    fill_in "Portf analysis rating", with: @groups_eval.portf_analysis_rating
+    fill_in "Portf plan rating", with: @groups_eval.portf_plan_rating
+    fill_in "Poster abstract rating", with: @groups_eval.poster_abstract_rating
+    fill_in "Poster citation rating", with: @groups_eval.poster_citation_rating
+    fill_in "Poster design rating", with: @groups_eval.poster_design_rating
+    fill_in "Poster discussion rating", with: @groups_eval.poster_discussion_rating
+    fill_in "Poster intro abstr rating", with: @groups_eval.poster_intro_abstr_rating
+    fill_in "Poster mat meth rating", with: @groups_eval.poster_mat_meth_rating
+    fill_in "Poster results rating", with: @groups_eval.poster_results_rating
+    fill_in "Poster summary comments", with: @groups_eval.poster_summary_comments
+    fill_in "Proto rating", with: @groups_eval.proto_rating
+    fill_in "Proto title rating", with: @groups_eval.proto_title_rating
+    fill_in "School", with: @groups_eval.school_id
+    fill_in "Semester", with: @groups_eval.semester
+    fill_in "Updated at", with: @groups_eval.updated_at
+    fill_in "Year", with: @groups_eval.year_id
+    click_on "Create Groups eval"
+
+    assert_text "Groups eval was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Groups eval" do
+    visit groups_evals_url
+    click_on "Edit", match: :first
+
+    fill_in "Created at", with: @groups_eval.created_at
+    fill_in "Evaluator group user", with: @groups_eval.evaluator_group_user_id
+    fill_in "Evaluator user", with: @groups_eval.evaluator_user_id
+    fill_in "Grade", with: @groups_eval.grade
+    fill_in "Group", with: @groups_eval.group_id
+    check "Invalid" if @groups_eval.invalid
+    fill_in "Portf analysis rating", with: @groups_eval.portf_analysis_rating
+    fill_in "Portf plan rating", with: @groups_eval.portf_plan_rating
+    fill_in "Poster abstract rating", with: @groups_eval.poster_abstract_rating
+    fill_in "Poster citation rating", with: @groups_eval.poster_citation_rating
+    fill_in "Poster design rating", with: @groups_eval.poster_design_rating
+    fill_in "Poster discussion rating", with: @groups_eval.poster_discussion_rating
+    fill_in "Poster intro abstr rating", with: @groups_eval.poster_intro_abstr_rating
+    fill_in "Poster mat meth rating", with: @groups_eval.poster_mat_meth_rating
+    fill_in "Poster results rating", with: @groups_eval.poster_results_rating
+    fill_in "Poster summary comments", with: @groups_eval.poster_summary_comments
+    fill_in "Proto rating", with: @groups_eval.proto_rating
+    fill_in "Proto title rating", with: @groups_eval.proto_title_rating
+    fill_in "School", with: @groups_eval.school_id
+    fill_in "Semester", with: @groups_eval.semester
+    fill_in "Updated at", with: @groups_eval.updated_at
+    fill_in "Year", with: @groups_eval.year_id
+    click_on "Update Groups eval"
+
+    assert_text "Groups eval was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Groups eval" do
+    visit groups_evals_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Groups eval was successfully destroyed"
+  end
+end


### PR DESCRIPTION
TO DO: 
- Fix field name of 'invalid' issue, and then remove workaround from app/models/groups_eval.rb.
- Clean up extra scaffolding actions, views, and test fixtures.