### PR TITLE
update without csrf for prototype

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  self.allow_forgery_protection = false
 end


### PR DESCRIPTION
can now post without csrf token in header.
note expects nested parameters (e.g. groups_eval[year_id], groups_eval[school_id], ...
